### PR TITLE
Adds TPlains Application link in an F.A.Q.

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,6 +488,14 @@
                 </div>
               </div>
               <div class="faq-wrap">
+                <h3 class="faq-q">Q: Is there any application available for this Conference?</h3>
+                <div class="faq-a">
+                  <p>Yes! There is a ready-to-use, mobile-friendly web application available for this Conference. No download needed.
+                    <a href="https://thunderplains-2024.sessionize.com">Check out the TPlains 2024.</a>
+                  </p>
+                </div>
+              </div>
+              <div class="faq-wrap">
                 <h3 class="faq-q">Q: How do I become a sponsor?</h3>
                 <div class="faq-a">
                   <p>


### PR DESCRIPTION
Adds an Frequently Asked Questions (FAQ) entry to provide the TPlains 2024 application link, required in #15

![image](https://github.com/user-attachments/assets/73d4c010-c96d-4ec9-b13d-16311c44038c)

Please review the FAQ content to check for its correctness.